### PR TITLE
fix errors for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ pimmi fill demo_dataset/dataset1 my_index
 pimmi query demo_dataset/dataset1 my_index -o result_query.csv
 
 # Post process the mining results in order to visualize them
-pimmi clusters my_index result_query.csv
+pimmi clusters my_index result_query.csv clusters.json
 
 # You can also play with the configuration parameters. First, generate a default configuration file
 pimmi create-config my_pimmi_conf.yml

--- a/pimmi/cli/__main__.py
+++ b/pimmi/cli/__main__.py
@@ -216,7 +216,7 @@ def fill(image_dir, index_dir, nb_img, erase=False, force=False, **kwargs):
                             "Please restart pimmi fill with '--erase' or choose another directory.")
                         sys.exit(1)
         else:
-            os.mkdir(index_dir)
+            os.makedirs(index_dir, exist_ok=True)
             index_exists = False
         # todo: error if one file exists but not the other
 

--- a/pimmi/clusters.py
+++ b/pimmi/clusters.py
@@ -66,6 +66,9 @@ def generate_graph_from_files(file_patterns, min_nb_match_ransac):
                     nb_match_ransac = reader.headers["nb_match_ransac"]
 
                     for row in reader:
+                        # sometimes there are empty rows, maybe there is a better fix when creating the csv ?
+                        if row == []:
+                            continue
                         if row[query_image_id] != row[result_image_id] and int(row[nb_match_ransac]) >= min_nb_match_ransac:
                             yield int(row[query_image_id]), int(row[result_image_id]), int(row[nb_match_ransac])
     else:


### PR DESCRIPTION
Process in fork mode don't work on windows and cv2 items could not be pickled in spawn mode. 
So I switched to use Threads instead of Processes on windows.

Also made some qui fixes to ignore empty rows since casanova reader seems to add empty rows in csv on windows ? Or maybe it's just an error somewhere in the code. Anyway, empty rows are now ignored when parsing the csv. 

Also added an outputfile example in the readme in order to have a "real" result when making clusters.